### PR TITLE
Mlebabeclap aniso

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -764,7 +764,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                             Real alpha, Array4<Real const> const& a,
                             Real dhx, Real dhy, Real dh,
-                            const amrex::GpuArray<double, 2> dx,
+                            const amrex::GpuArray<Real, AMREX_SPACEDIM> dx,
                             Array4<Real const> const& bX, Array4<Real const> const& bY,
                             Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,
                             Array4<Real const> const& vfrc,

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -15,7 +15,7 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
                         Array4<Real const> const& vfrc,
                         Array4<Real const> const& apx, Array4<Real const> const& apy,
                         Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                        Array4<Real const> const& ccent, Array4<Real const> const& ba,
+                        Array4<Real const> const& ccent,
                         Array4<Real const> const& bcent, Array4<Real const> const& beb,
                         Array4<Real const> const& phieb,
                         const int& domlo_x,    const int& domlo_y,
@@ -27,6 +27,7 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
     Real dhy = beta*dxinv[1]*dxinv[1];
+    Real dh  = beta*dxinv[0]*dxinv[1];
 
     amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
@@ -138,24 +139,26 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
             Real feb = 0.0;
             if (is_eb_dirichlet && flag(i,j,k).isSingleValued())
             {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
+                Real dapx = (apxm-apxp) /dxinv[1];
+                Real dapy = (apym-apyp)/dxinv[0];
                 Real anorm = std::hypot(dapx,dapy);
                 Real anorminv = 1.0/anorm;
                 Real anrmx = dapx * anorminv;
                 Real anrmy = dapy * anorminv;
+                Real scaling = std::sqrt( (anrmx/dxinv[0])*(anrmx/dxinv[0]) + (anrmy/dxinv[1])*(anrmy/dxinv[1]) );
+
 
                 feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
                                                          anrmx,anrmy,is_eb_inhomog,
                                                          on_x_face, domlo_x, domhi_x,
                                                          on_y_face, domlo_y, domhi_y);
 
-                feb *= ba(i,j,k) * beb(i,j,k,n);
+                feb *= anorm/scaling * beb(i,j,k,n);
             }
 
 
             y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (1.0/kappa) *
-                (dhx*(apxm*fxm-apxp*fxp) + dhy*(apym*fym-apyp*fyp) - dhx*feb);
+                (dhx*(apxm*fxm-apxp*fxp) + dhy*(apym*fym-apyp*fyp) - dh*feb);
         }
     });
 }
@@ -167,7 +170,7 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
                         Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,
                         Array4<Real const> const& vfrc, Array4<Real const> const& apx,
                         Array4<Real const> const& apy, Array4<Real const> const& fcx,
-                        Array4<Real const> const& fcy, Array4<Real const> const& ba,
+                        Array4<Real const> const& fcy,
                         Array4<Real const> const& bc, Array4<Real const> const& beb,
                         bool is_dirichlet, Array4<Real const> const& phieb,
                         bool is_inhomog, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
@@ -176,6 +179,8 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
     Real dhy = beta*dxinv[1]*dxinv[1];
+    Real dh  = beta*dxinv[0]*dxinv[1];
+
 
     bool beta_on_center = !(beta_on_centroid);
     bool  phi_on_center = !( phi_on_centroid);
@@ -248,13 +253,14 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real feb = 0.0_rt;
             if (is_dirichlet) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
+                Real dapx = (apxm-apxp)/dxinv[1];
+                Real dapy = (apym-apyp)/dxinv[0];
                 Real anorm = std::hypot(dapx,dapy);
                 Real anorminv = 1.0/anorm;
                 Real anrmx = dapx * anorminv;
                 Real anrmy = dapy * anorminv;
 
+                Real scaling = std::sqrt( (anrmx/dxinv[0])*(anrmx/dxinv[0]) + (anrmy/dxinv[1])*(anrmy/dxinv[1]) );
                 Real phib = is_inhomog ? phieb(i,j,k,n) : 0.0_rt;
 
                 Real bctx = bc(i,j,k,0);
@@ -264,17 +270,13 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
                 Real dg, gx, gy, sx, sy;
                 if (amrex::Math::abs(anrmx) > amrex::Math::abs(anrmy)) {
                     dg = dx_eb / amrex::Math::abs(anrmx);
-                    gx = bctx - dg*anrmx;
-                    gy = bcty - dg*anrmy;
-                    sx = amrex::Math::copysign(1.0_rt,anrmx);
-                    sy = amrex::Math::copysign(1.0_rt,anrmy);
                 } else {
                     dg = dx_eb / amrex::Math::abs(anrmy);
-                    gx = bctx - dg*anrmx;
-                    gy = bcty - dg*anrmy;
-                    sx = amrex::Math::copysign(1.0_rt,anrmx);
-                    sy = amrex::Math::copysign(1.0_rt,anrmy);
                 }
+                gx = (bctx - dg*anrmx);
+                gy = (bcty - dg*anrmy);
+                sx = amrex::Math::copysign(1.0_rt,anrmx);
+                sy = amrex::Math::copysign(1.0_rt,anrmy);
 
                 int ii = i - static_cast<int>(sx);
                 int jj = j - static_cast<int>(sy);
@@ -284,14 +286,14 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
                     +       (            - gy*sy - gx*gy*sx*sy) * x(i ,jj,k,n)
                     +       (                    + gx*gy*sx*sy) * x(ii,jj,k,n) ;
 
-                Real dphidn = (phib-phig) / dg;
+                Real dphidn = (phib-phig) / (dg*scaling);
 
-                feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
+                feb = dphidn * anorm * beb(i,j,k,n);
             }
 
             y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (1.0/kappa) *
                 (dhx*(apxm*fxm-apxp*fxp) +
-                 dhy*(apym*fym-apyp*fyp) - dhx*feb);
+                 dhy*(apym*fym-apyp*fyp) - dh*feb);
         }
     });
 }
@@ -310,7 +312,6 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
                          bool is_inhomog,
                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real dhx = dxinv[0];
 
     if (!flag(i,j,k).isSingleValued())
     {
@@ -324,12 +325,14 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
         Real apym = apy(i,j,k);
         Real apyp = apy(i,j+1,k);
 
-        Real dapx = apxm-apxp;
-        Real dapy = apym-apyp;
+        Real dapx = (apxm-apxp)/dxinv[1];
+        Real dapy = (apym-apyp)/dxinv[0];
         Real anorm = std::hypot(dapx,dapy);
         Real anorminv = 1.0/anorm;
         Real anrmx = dapx * anorminv;
         Real anrmy = dapy * anorminv;
+        Real scaling = std::sqrt( (anrmx/dxinv[0])*(anrmx/dxinv[0]) + (anrmy/dxinv[1])*(anrmy/dxinv[1]) );
+
 
         Real phib = is_inhomog ? phieb(i,j,k,n) : 0.0_rt;
 
@@ -340,17 +343,13 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
         Real dg, gx, gy, sx, sy;
         if (amrex::Math::abs(anrmx) > amrex::Math::abs(anrmy)) {
             dg = dx_eb / amrex::Math::abs(anrmx);
-            gx = bctx - dg*anrmx;
-            gy = bcty - dg*anrmy;
-            sx = amrex::Math::copysign(1.0_rt,anrmx);
-            sy = amrex::Math::copysign(1.0_rt,anrmy);
         } else {
             dg = dx_eb / amrex::Math::abs(anrmy);
-            gx = bctx - dg*anrmx;
-            gy = bcty - dg*anrmy;
-            sx = amrex::Math::copysign(1.0_rt,anrmx);
-            sy = amrex::Math::copysign(1.0_rt,anrmy);
         }
+        gx = bctx - dg*anrmx;
+        gy = bcty - dg*anrmy;
+        sx = amrex::Math::copysign(1.0_rt,anrmx);
+        sy = amrex::Math::copysign(1.0_rt,anrmy);
 
         int ii = i - static_cast<int>(sx);
         int jj = j - static_cast<int>(sy);
@@ -360,7 +359,7 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
             +       (            - gy*sy - gx*gy*sx*sy) * x(i ,jj,k,n)
             +       (                    + gx*gy*sx*sy) * x(ii,jj,k,n) ;
 
-        Real dphidn = dhx*(phib-phig)/dg;
+        Real dphidn = (phib-phig)/(dg*scaling);
         feb(i,j,k,n) = -beb(i,j,k,n) * dphidn;
     }
 }
@@ -369,7 +368,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebabeclap_gsrb (Box const& box,
                        Array4<Real> const& phi, Array4<Real const> const& rhs,
                        Real alpha, Array4<Real const> const& a,
-                       Real dhx, Real dhy,
+                       Real dhx, Real dhy, Real dh,
+                       GpuArray<Real,AMREX_SPACEDIM> const& dx,
                        Array4<Real const> const& bX, Array4<Real const> const& bY,
                        Array4<int const> const& m0, Array4<int const> const& m2,
                        Array4<int const> const& m1, Array4<int const> const& m3,
@@ -379,7 +379,7 @@ void mlebabeclap_gsrb (Box const& box,
                        Array4<Real const> const& vfrc,
                        Array4<Real const> const& apx, Array4<Real const> const& apy,
                        Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                       Array4<Real const> const& ba, Array4<Real const> const& bc,
+                       Array4<Real const> const& bc,
                        Array4<Real const> const& beb,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
                        Box const& vbox, int redblack, int ncomp) noexcept
@@ -533,12 +533,15 @@ void mlebabeclap_gsrb (Box const& box,
                          dhy*(apym*oym-apyp*oyp));
 
                     if (is_dirichlet) {
-                        Real dapx = apxm-apxp;
-                        Real dapy = apym-apyp;
+                        Real dapx = (apxm-apxp)*dx[1];
+                        Real dapy = (apym-apyp)*dx[0];
                         Real anorm = std::hypot(dapx,dapy);
                         Real anorminv = 1.0/anorm;
                         Real anrmx = dapx * anorminv;
                         Real anrmy = dapy * anorminv;
+                        Real scaling = std::sqrt( (anrmx*dx[0])*(anrmx*dx[0]) +
+                                (anrmy*dx[1])*(anrmy*dx[1]) );
+
 
                         Real bctx = bc(i,j,k,0);
                         Real bcty = bc(i,j,k,1);
@@ -547,17 +550,13 @@ void mlebabeclap_gsrb (Box const& box,
                         Real dg, gx, gy, sx, sy;
                         if (amrex::Math::abs(anrmx) > amrex::Math::abs(anrmy)) {
                             dg = dx_eb / amrex::Math::abs(anrmx);
-                            gx = bctx - dg*anrmx;
-                            gy = bcty - dg*anrmy;
-                            sx = amrex::Math::copysign(1.0_rt,anrmx);
-                            sy = amrex::Math::copysign(1.0_rt,anrmy);
                         } else {
                             dg = dx_eb / amrex::Math::abs(anrmy);
-                            gx = bctx - dg*anrmx;
-                            gy = bcty - dg*anrmy;
-                            sx = amrex::Math::copysign(1.0_rt,anrmx);
-                            sy = amrex::Math::copysign(1.0_rt,anrmy);
                         }
+                        gx = bctx - dg*anrmx;
+                        gy = bcty - dg*anrmy;
+                        sx = amrex::Math::copysign(1.0_rt,anrmx);
+                        sy = amrex::Math::copysign(1.0_rt,anrmy);
 
                         int ii = i - static_cast<int>(sx);
                         int jj = j - static_cast<int>(sy);
@@ -568,13 +567,13 @@ void mlebabeclap_gsrb (Box const& box,
                             +       (                    + gx*gy*sx*sy) * phi(ii,jj,k,n);
 
                         // In gsrb we are always in residual-correction form so phib = 0
-                        Real dphidn =  (    -phig)/dg;
+                        Real dphidn =  (    -phig)/(dg*scaling);
 
-                        Real feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
-                        rho += -vfrcinv*(-dhx)*feb;
+                        Real feb = dphidn * anorm * beb(i,j,k,n);
+                        rho += -vfrcinv*(-dh)*feb;
 
-                        Real feb_gamma = -phig_gamma/dg * ba(i,j,k) * beb(i,j,k,n);
-                        gamma += vfrcinv*(-dhx)*feb_gamma;
+                        Real feb_gamma = -phig_gamma/(dg*scaling) * anorm * beb(i,j,k,n);
+                        gamma += vfrcinv*(-dh)*feb_gamma;
                     }
 
                     Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
@@ -764,13 +763,14 @@ void mlebabeclap_grad_y_0 (Box const& box, Array4<Real> const& gy, Array4<Real c
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                             Real alpha, Array4<Real const> const& a,
-                            Real dhx, Real dhy,
+                            Real dhx, Real dhy, Real dh,
+                            const amrex::GpuArray<double, 2> dx,
                             Array4<Real const> const& bX, Array4<Real const> const& bY,
                             Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,
                             Array4<Real const> const& vfrc,
                             Array4<Real const> const& apx, Array4<Real const> const& apy,
                             Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                            Array4<Real const> const& ba, Array4<Real const> const& bc,
+                            Array4<Real const> const& bc,
                             Array4<Real const> const& beb,
                             bool is_dirichlet, bool beta_on_centroid, int ncomp) noexcept
 {
@@ -827,12 +827,15 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                  dhy*(apym*sym-apyp*syp));
 
             if (is_dirichlet) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
+                Real dapx = (apxm-apxp)*dx[1];
+                Real dapy = (apym-apyp)*dx[0];
                 Real anorm = std::hypot(dapx,dapy);
                 Real anorminv = 1.0/anorm;
                 Real anrmx = dapx * anorminv;
                 Real anrmy = dapy * anorminv;
+
+                Real scaling = std::sqrt( (anrmx*dx[0])*(anrmx*dx[0]) +
+                        (anrmy*dx[1])*(anrmy*dx[1]) );
 
                 Real bctx = bc(i,j,k,0);
                 Real bcty = bc(i,j,k,1);
@@ -841,21 +844,17 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                 Real dg, gx, gy, sx, sy;
                 if (amrex::Math::abs(anrmx) > amrex::Math::abs(anrmy)) {
                     dg = dx_eb / amrex::Math::abs(anrmx);
-                    gx = bctx - dg*anrmx;
-                    gy = bcty - dg*anrmy;
-                    sx = amrex::Math::copysign(1.0_rt,anrmx);
-                    sy = amrex::Math::copysign(1.0_rt,anrmy);
                 } else {
                     dg = dx_eb / amrex::Math::abs(anrmy);
-                    gx = bctx - dg*anrmx;
-                    gy = bcty - dg*anrmy;
-                    sx = amrex::Math::copysign(1.0_rt,anrmx);
-                    sy = amrex::Math::copysign(1.0_rt,anrmy);
                 }
+                gx = bctx - dg*anrmx;
+                gy = bcty - dg*anrmy;
+                sx = amrex::Math::copysign(1.0_rt,anrmx);
+                sy = amrex::Math::copysign(1.0_rt,anrmy);
 
                 Real phig_gamma = (1.0 + gx*sx + gy*sy + gx*gy*sx*sy);
-                Real feb_gamma = -phig_gamma/dg * ba(i,j,k) * beb(i,j,k,n);
-                gamma += vfrcinv*(-dhx)*feb_gamma;
+                Real feb_gamma = -phig_gamma/(dg*scaling) * anorm * beb(i,j,k,n);
+                gamma += vfrcinv*(-dh)*feb_gamma;
             }
 
             phi(i,j,k,n) /= gamma;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -1232,7 +1232,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                             Real alpha, Array4<Real const> const& a,
                             Real dhx, Real dhy, Real dhz, Real dh,
-                            const amrex::GpuArray<double, 3> dx,
+                            const amrex::GpuArray<Real, AMREX_SPACEDIM> dx,
                             Array4<Real const> const& bX, Array4<Real const> const& bY,
                             Array4<Real const> const& bZ,
                             Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -1342,7 +1342,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                 Real anorminv = 1.0/anorm;
                 Real anrmx = dapx * anorminv;
                 Real anrmy = dapy * anorminv;
-                Real anrmz = dapz * anorminv;           
+                Real anrmz = dapz * anorminv;
                 Real scaling = std::sqrt( (anrmx*dx[0])*(anrmx*dx[0]) +
                         (anrmy*dx[1])*(anrmy*dx[1]) +
                         (anrmz*dx[2])*(anrmz*dx[2]) );

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -17,7 +17,7 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
                         Array4<Real const> const& apy, Array4<Real const> const& apz,
                         Array4<Real const> const& fcx, Array4<Real const> const& fcy,
                         Array4<Real const> const& fcz,
-                        Array4<Real const> const& ccent, Array4<Real const> const& ba,
+                        Array4<Real const> const& ccent,
                         Array4<Real const> const& bcent, Array4<Real const> const& beb,
                         Array4<Real const> const& phieb,
                         const int& domlo_x, const int& domlo_y, const int& domlo_z,
@@ -30,6 +30,7 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
     Real dhx = beta*dxinv[0]*dxinv[0];
     Real dhy = beta*dxinv[1]*dxinv[1];
     Real dhz = beta*dxinv[2]*dxinv[2];
+    Real dh = beta*dxinv[0]*dxinv[1]*dxinv[2];
 
     amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
@@ -187,27 +188,31 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
 
             Real feb = 0.0;
             if (is_eb_dirichlet && flag(i,j,k).isSingleValued()) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
-                Real dapz = apzm-apzp;
+                Real dapx = (apxm-apxp)/(dxinv[1]*dxinv[2]);
+                Real dapy = (apym-apyp)/(dxinv[0]*dxinv[2]);
+                Real dapz = (apzm-apzp)/(dxinv[0]*dxinv[1]);
                 Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
                 Real anorminv = 1.0/anorm;
                 Real anrmx = dapx * anorminv;
                 Real anrmy = dapy * anorminv;
                 Real anrmz = dapz * anorminv;
+                Real scaling = std::sqrt( (anrmx/dxinv[0])*(anrmx/dxinv[0]) +
+                        (anrmy/dxinv[1])*(anrmy/dxinv[1]) +
+                        (anrmz/dxinv[2])*(anrmz/dxinv[2]));
+
 
                 feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
                                                          anrmx,anrmy,anrmz,is_eb_inhomog,
                                                          on_x_face,domlo_x,domhi_x,
                                                          on_y_face,domlo_y,domhi_y,
                                                          on_z_face,domlo_z,domhi_z);
-                feb *= ba(i,j,k) * beb(i,j,k,n);
+                feb *= anorm/scaling * beb(i,j,k,n);
             }
 
             y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (1.0/kappa) *
                 (dhx*(apxm*fxm - apxp*fxp) +
                  dhy*(apym*fym - apyp*fyp) +
-                 dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
+                 dhz*(apzm*fzm - apzp*fzp) - dh*feb);
         }
     });
 }
@@ -221,7 +226,7 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
                         Array4<Real const> const& vfrc, Array4<Real const> const& apx,
                         Array4<Real const> const& apy, Array4<Real const> const& apz,
                         Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                        Array4<Real const> const& fcz, Array4<Real const> const& ba,
+                        Array4<Real const> const& fcz,
                         Array4<Real const> const& bc, Array4<Real const> const& beb,
                         bool is_dirichlet, Array4<Real const> const& phieb,
                         bool is_inhomog, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
@@ -231,6 +236,7 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
     Real dhx = beta*dxinv[0]*dxinv[0];
     Real dhy = beta*dxinv[1]*dxinv[1];
     Real dhz = beta*dxinv[2]*dxinv[2];
+    Real dh  = beta*dxinv[0]*dxinv[1]*dxinv[2];
 
     bool beta_on_center = !(beta_on_centroid);
     bool  phi_on_center = !( phi_on_centroid);
@@ -406,14 +412,18 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real feb = 0.0;
             if (is_dirichlet) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
-                Real dapz = apzm-apzp;
+                Real dapx = (apxm-apxp)/(dxinv[1]*dxinv[2]);
+                Real dapy = (apym-apyp)/(dxinv[0]*dxinv[2]);
+                Real dapz = (apzm-apzp)/(dxinv[0]*dxinv[1]);
                 Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
                 Real anorminv = 1.0/anorm;
                 Real anrmx = dapx * anorminv;
                 Real anrmy = dapy * anorminv;
                 Real anrmz = dapz * anorminv;
+                Real scaling = std::sqrt( (anrmx/dxinv[0])*(anrmx/dxinv[0]) +
+                        (anrmy/dxinv[1])*(anrmy/dxinv[1]) +
+                        (anrmz/dxinv[2])*(anrmz/dxinv[2]));
+
 
                 Real phib = is_inhomog ? phieb(i,j,k,n) : 0.0_rt;
 
@@ -450,15 +460,15 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
                     +       (gxy + gxyz)                    * x(ii,jj,k ,n)
                     +       (-gxyz)                         * x(ii,jj,kk,n);
 
-                Real dphidn = (phib-phig)/dg;
+                Real dphidn = (phib-phig)/(dg*scaling);
 
-                feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
+                feb = dphidn * anorm * beb(i,j,k,n);
             }
 
             y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (1.0/kappa) *
                 (dhx*(apxm*fxm - apxp*fxp) +
                  dhy*(apym*fym - apyp*fyp) +
-                 dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
+                 dhz*(apzm*fzm - apzp*fzp) - dh*feb);
         }
     });
 }
@@ -478,7 +488,6 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
                          bool is_inhomog,
                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real dhx = dxinv[0];
 
     if (!flag(i,j,k).isSingleValued())
     {
@@ -494,14 +503,17 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
         Real apzm = apz(i,j,k);
         Real apzp = apz(i,j,k+1);
 
-        Real dapx = apxm-apxp;
-        Real dapy = apym-apyp;
-        Real dapz = apzm-apzp;
+        Real dapx = (apxm-apxp)/(dxinv[1]*dxinv[2]);
+        Real dapy = (apym-apyp)/(dxinv[0]*dxinv[2]);
+        Real dapz = (apzm-apzp)/(dxinv[0]*dxinv[1]);
         Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
         Real anorminv = 1.0/anorm;
         Real anrmx = dapx * anorminv;
         Real anrmy = dapy * anorminv;
         Real anrmz = dapz * anorminv;
+        Real scaling = std::sqrt( (anrmx/dxinv[0])*(anrmx/dxinv[0]) +
+                (anrmy/dxinv[1])*(anrmy/dxinv[1]) +
+                (anrmz/dxinv[2])*(anrmz/dxinv[2]));
 
         Real phib = is_inhomog ? phieb(i,j,k,n) : 0.0_rt;
 
@@ -537,7 +549,7 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
             +       (gxy + gxyz)                    * x(ii,jj,k ,n)
             +       (-gxyz)                         * x(ii,jj,kk,n);
 
-        Real dphidn = dhx*(phib-phig)/dg;
+        Real dphidn = (phib-phig)/(dg*scaling);
         feb(i,j,k,n) = -beb(i,j,k,n) * dphidn;
     }
 }
@@ -546,7 +558,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebabeclap_gsrb (Box const& box,
                        Array4<Real> const& phi, Array4<Real const> const& rhs,
                        Real alpha, Array4<Real const> const& a,
-                       Real dhx, Real dhy, Real dhz,
+                       Real dhx, Real dhy, Real dhz, Real dh,
+                       GpuArray<Real,AMREX_SPACEDIM> const& dx,
                        Array4<Real const> const& bX, Array4<Real const> const& bY,
                        Array4<Real const> const& bZ,
                        Array4<int const> const& m0, Array4<int const> const& m2,
@@ -562,8 +575,7 @@ void mlebabeclap_gsrb (Box const& box,
                        Array4<Real const> const& apx, Array4<Real const> const& apy,
                        Array4<Real const> const& apz,
                        Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                       Array4<Real const> const& fcz,
-                       Array4<Real const> const& ba, Array4<Real const> const& bc,
+                       Array4<Real const> const& fcz, Array4<Real const> const& bc,
                        Array4<Real const> const& beb,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
                        Box const& vbox, int redblack, int ncomp) noexcept
@@ -832,14 +844,18 @@ void mlebabeclap_gsrb (Box const& box,
                          dhz*(apzm*ozm-apzp*ozp));
 
                     if (is_dirichlet) {
-                        Real dapx = apxm-apxp;
-                        Real dapy = apym-apyp;
-                        Real dapz = apzm-apzp;
+                        Real dapx = (apxm-apxp)*(dx[1]*dx[2]);
+                        Real dapy = (apym-apyp)*(dx[0]*dx[2]);
+                        Real dapz = (apzm-apzp)*(dx[0]*dx[1]);
                         Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
                         Real anorminv = 1.0/anorm;
                         Real anrmx = dapx * anorminv;
                         Real anrmy = dapy * anorminv;
                         Real anrmz = dapz * anorminv;
+                        Real scaling = std::sqrt( (anrmx*dx[0])*(anrmx*dx[0]) +
+                                (anrmy*dx[1])*(anrmy*dx[1]) +
+                                (anrmz*dx[2])*(anrmz*dx[2]));
+
                         Real bctx = bc(i,j,k,0);
                         Real bcty = bc(i,j,k,1);
                         Real bctz = bc(i,j,k,2);
@@ -874,11 +890,11 @@ void mlebabeclap_gsrb (Box const& box,
                             + (gxy + gxyz) * phi(ii,jj,k,n)
                             + (-gxyz) * phi(ii,jj,kk,n);
 
-                        Real dphidn    = (    -phig)/dg;
-                        Real feb_gamma = -phig_gamma/dg * ba(i,j,k) * beb(i,j,k,n);
-                        gamma += vfrcinv*(-dhx)*feb_gamma;
-                        Real feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
-                        rho += -vfrcinv*(-dhx)*feb;
+                        Real dphidn    = (    -phig)/(dg*scaling);
+                        Real feb_gamma = -phig_gamma/(dg*scaling) * anorm * beb(i,j,k,n);
+                        gamma += vfrcinv*(-dh)*feb_gamma;
+                        Real feb = dphidn * anorm * beb(i,j,k,n);
+                        rho += -vfrcinv*(-dh)*feb;
                     }
 
                     Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
@@ -1215,7 +1231,8 @@ void mlebabeclap_grad_z_0 (Box const& box, Array4<Real> const& gz, Array4<Real c
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                             Real alpha, Array4<Real const> const& a,
-                            Real dhx, Real dhy, Real dhz,
+                            Real dhx, Real dhy, Real dhz, Real dh,
+                            const amrex::GpuArray<double, 3> dx,
                             Array4<Real const> const& bX, Array4<Real const> const& bY,
                             Array4<Real const> const& bZ,
                             Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,
@@ -1223,8 +1240,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                             Array4<Real const> const& apx, Array4<Real const> const& apy,
                             Array4<Real const> const& apz,
                             Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                            Array4<Real const> const& fcz,
-                            Array4<Real const> const& ba, Array4<Real const> const& bc,
+                            Array4<Real const> const& fcz, Array4<Real const> const& bc,
                             Array4<Real const> const& beb,
                             bool is_dirichlet, bool beta_on_centroid, int ncomp) noexcept
 {
@@ -1319,14 +1335,17 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                  dhz*(apzm*szm-apzp*szp));
 
             if (is_dirichlet) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
-                Real dapz = apzm-apzp;
+                Real dapx = (apxm-apxp)*dx[1]*dx[2];
+                Real dapy = (apym-apyp)*dx[0]*dx[2];
+                Real dapz = (apzm-apzp)*dx[0]*dx[1];
                 Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
                 Real anorminv = 1.0/anorm;
                 Real anrmx = dapx * anorminv;
                 Real anrmy = dapy * anorminv;
-                Real anrmz = dapz * anorminv;
+                Real anrmz = dapz * anorminv;           
+                Real scaling = std::sqrt( (anrmx*dx[0])*(anrmx*dx[0]) +
+                        (anrmy*dx[1])*(anrmy*dx[1]) +
+                        (anrmz*dx[2])*(anrmz*dx[2]) );
                 Real bctx = bc(i,j,k,0);
                 Real bcty = bc(i,j,k,1);
                 Real bctz = bc(i,j,k,2);
@@ -1350,8 +1369,8 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                 Real gyz = gy*gz;
                 Real gxyz = gx*gy*gz;
                 Real phig_gamma = (1.0+gx+gy+gz+gxy+gxz+gyz+gxyz);
-                Real feb_gamma = -phig_gamma/dg * ba(i,j,k) * beb(i,j,k,n);
-                gamma += vfrcinv*(-dhx)*feb_gamma;
+                Real feb_gamma = -phig_gamma/(dg*scaling) * anorm * beb(i,j,k,n);
+                gamma += vfrcinv*(-dh)*feb_gamma;
             }
 
             phi(i,j,k,n) /= gamma;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -28,7 +28,6 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
         : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
     auto fcent = (factory) ? factory->getFaceCent()
         : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
-    const MultiCutFab* barea = (factory) ? &(factory->getBndryArea()) : nullptr;
     const MultiCutFab* bcent = (factory) ? &(factory->getBndryCent()) : nullptr;
     const auto         ccent = (factory) ? &(factory->getCentroid()) : nullptr;
 
@@ -96,7 +95,6 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
             AMREX_D_TERM(Array4<Real const> const& fcxfab = fcent[0]->const_array(mfi);,
                          Array4<Real const> const& fcyfab = fcent[1]->const_array(mfi);,
                          Array4<Real const> const& fczfab = fcent[2]->const_array(mfi););
-            Array4<Real const> const& bafab = barea->const_array(mfi);
             Array4<Real const> const& bcfab = bcent->const_array(mfi);
             Array4<Real const> const& ccfab = ccent->const_array(mfi);
             Array4<Real const> const& bebfab = (is_eb_dirichlet)
@@ -127,7 +125,7 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                                      flagfab, vfracfab,
                                      AMREX_D_DECL(apxfab,apyfab,apzfab),
                                      AMREX_D_DECL(fcxfab,fcyfab,fczfab),
-                                     ccfab, bafab, bcfab, bebfab, phiebfab,
+                                     ccfab, bcfab, bebfab, phiebfab,
                                      AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
                                      AMREX_D_DECL(extdir_x, extdir_y, extdir_z),
@@ -142,7 +140,7 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                                      ccmfab, flagfab, vfracfab,
                                      AMREX_D_DECL(apxfab,apyfab,apzfab),
                                      AMREX_D_DECL(fcxfab,fcyfab,fczfab),
-                                     bafab, bcfab, bebfab,
+                                     bcfab, bebfab,
                                      is_eb_dirichlet,
                                      phiebfab,
                                      is_eb_inhomog, dxinvarr,
@@ -191,10 +189,19 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
 #endif
 
     const int nc = getNComp();
-    const Real* h = m_geom[amrlev][mglev].CellSize();
+    const auto h = m_geom[amrlev][mglev].CellSizeArray();
     AMREX_D_TERM(const Real dhx = m_b_scalar/(h[0]*h[0]);,
                  const Real dhy = m_b_scalar/(h[1]*h[1]);,
                  const Real dhz = m_b_scalar/(h[2]*h[2]));
+#if (AMREX_SPACEDIM == 1 )
+    const Real dh = m_b_scalar/h[0];
+#endif
+#if (AMREX_SPACEDIM == 2 )
+    const Real dh = m_b_scalar/(h[0]*h[1]);
+#endif
+#if (AMREX_SPACEDIM == 3 )
+    const Real dh = m_b_scalar/(h[0]*h[1]*h[2]);
+#endif
     const Real alpha = m_a_scalar;
 
     auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
@@ -204,7 +211,6 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
         : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
     auto fcent = (factory) ? factory->getFaceCent()
         : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
-    const MultiCutFab* barea = (factory) ? &(factory->getBndryArea()) : nullptr;
     const MultiCutFab* bcent = (factory) ? &(factory->getBndryCent()) : nullptr;
 
     bool is_eb_dirichlet =  isEBDirichlet();
@@ -283,7 +289,6 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
             AMREX_D_TERM(Array4<Real const> const& fcxfab = fcent[0]->const_array(mfi);,
                          Array4<Real const> const& fcyfab = fcent[1]->const_array(mfi);,
                          Array4<Real const> const& fczfab = fcent[2]->const_array(mfi););
-            Array4<Real const> const& bafab = barea->const_array(mfi);
             Array4<Real const> const& bcfab = bcent->const_array(mfi);
             Array4<Real const> const& bebfab = (is_eb_dirichlet)
                 ? m_eb_b_coeffs[amrlev][mglev]->const_array(mfi) : foo;
@@ -297,6 +302,8 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
             {
                 mlebabeclap_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
                                  AMREX_D_DECL(dhx, dhy, dhz),
+                                 dh,
+                                 h,
                                  AMREX_D_DECL(bxfab,byfab,bzfab),
                                  AMREX_D_DECL(m0,m2,m4),
                                  AMREX_D_DECL(m1,m3,m5),
@@ -305,7 +312,7 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
                                  ccmfab, flagfab, vfracfab,
                                  AMREX_D_DECL(apxfab,apyfab,apzfab),
                                  AMREX_D_DECL(fcxfab,fcyfab,fczfab),
-                                 bafab, bcfab, bebfab,
+                                 bcfab, bebfab,
                                  is_eb_dirichlet, beta_on_centroid, phi_on_centroid,
                                  vbx, redblack, nc);
             });

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -401,6 +401,22 @@ struct ParticleTile
     }
 
     ///
+    /// Add a range of Real values to the struct-of-arrays for the given comp.
+    /// This sets the data for several particles at once.
+    ///
+    void push_back_real (int comp, amrex::Vector<amrex::ParticleReal>::const_iterator beg, amrex::Vector<amrex::ParticleReal>::const_iterator end) {
+        push_back_real(comp, &(*beg), &(*end));
+    }
+
+    ///
+    /// Add a range of Real values to the struct-of-arrays for the given comp.
+    /// This sets the data for several particles at once.
+    ///
+    void push_back_real (int comp, amrex::Vector<amrex::ParticleReal> const & vec) {
+        push_back_real(comp, vec.cbegin(), vec.cend());
+    }
+
+    ///
     /// Add npar copies of the Real value v to the struct-of-arrays for the given comp.
     /// This sets the data for several particles at once.
     ///
@@ -434,6 +450,22 @@ struct ParticleTile
     void push_back_int (int comp, const int* beg, const int* end) {
         auto it = m_soa_tile.GetIntData(comp).end();
         m_soa_tile.GetIntData(comp).insert(it, beg, end);
+    }
+
+    ///
+    /// Add a range of int values to the struct-of-arrays for the given comp.
+    /// This sets the data for several particles at once.
+    ///
+    void push_back_int (int comp, amrex::Vector<int>::const_iterator beg, amrex::Vector<int>::const_iterator end) {
+        push_back_int(comp, &(*beg), &(*end));
+    }
+
+    ///
+    /// Add a range of int values to the struct-of-arrays for the given comp.
+    /// This sets the data for several particles at once.
+    ///
+    void push_back_int (int comp, amrex::Vector<int> const & vec) {
+        push_back_int(comp, vec.cbegin(), vec.cend());
     }
 
     ///


### PR DESCRIPTION
## Summary

Implements some changes in MLEBABecLap that remove the assumption dx=dy=dz to enable anisotropic cells.

## Additional background

The changes concern the computations of the bondary flux Feb.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
